### PR TITLE
14 auto cd

### DIFF
--- a/cmd/cloudexec/launch.go
+++ b/cmd/cloudexec/launch.go
@@ -57,7 +57,8 @@ setup = '''
 
 '''
 
-# This command is run after the setup script completes.
+# This command is run from the input directory
+# after the setup script completes.
 run = ""
 `)
 

--- a/cmd/cloudexec/user_data.go
+++ b/cmd/cloudexec/user_data.go
@@ -19,7 +19,7 @@ type UserData struct {
 	SetupCommands     string
 	RunCommand        string
 	Timeout           string
-	InputDirectory           string
+	InputDirectory    string
 }
 
 //go:embed user_data.sh.tmpl
@@ -47,7 +47,7 @@ func GenerateUserData(config config.Config, lc LaunchConfig) (string, error) {
 		SetupCommands:     strings.ReplaceAll(lc.Commands.Setup, `"`, `\"`),
 		RunCommand:        strings.ReplaceAll(lc.Commands.Run, `"`, `\"`),
 		Timeout:           timeoutStr,
-		InputDirectory:         lc.Input.Directory,
+		InputDirectory:    lc.Input.Directory,
 	}
 
 	// Execute the template script with provided user data

--- a/cmd/cloudexec/user_data.go
+++ b/cmd/cloudexec/user_data.go
@@ -19,6 +19,7 @@ type UserData struct {
 	SetupCommands     string
 	RunCommand        string
 	Timeout           string
+	InputDirectory           string
 }
 
 //go:embed user_data.sh.tmpl
@@ -46,6 +47,7 @@ func GenerateUserData(config config.Config, lc LaunchConfig) (string, error) {
 		SetupCommands:     strings.ReplaceAll(lc.Commands.Setup, `"`, `\"`),
 		RunCommand:        strings.ReplaceAll(lc.Commands.Run, `"`, `\"`),
 		Timeout:           timeoutStr,
+		InputDirectory:         lc.Input.Directory,
 	}
 
 	// Execute the template script with provided user data

--- a/cmd/cloudexec/user_data.sh.tmpl
+++ b/cmd/cloudexec/user_data.sh.tmpl
@@ -213,6 +213,10 @@ fi
 
 echo "Unzipping input archive..."
 unzip "${home}/input.zip" -d "${home}/"
+if [[ ! -d "${home}/${INPUT_DIRECTORY}" ]]; then
+	echo "Error: Failed to unzip required ${INPUT_DIRECTORY} directory"
+	exit 1
+fi
 
 source "${home}/venv/bin/activate"
 

--- a/cmd/cloudexec/user_data.sh.tmpl
+++ b/cmd/cloudexec/user_data.sh.tmpl
@@ -128,12 +128,12 @@ cleanup() {
 		update_state "failed"
 	fi
 
-	output_files="$(ls -A "$home/output/")"
+	output_files="$(ls -A "${home}/output/")"
 	if [[ -n ${output_files} ]]; then
 		echo "Uploading results..."
-		s3cmd put -r "$home/output/*" "s3://${BUCKET_NAME}/job-${JOB_ID}/output/"
+		s3cmd put -r "${home}"/output/* "s3://${BUCKET_NAME}/job-${JOB_ID}/output/"
 	else
-		echo "Skipping results upload, no files found in $home/ouput"
+		echo "Skipping results upload, no files found in ${home}/ouput"
 	fi
 
 	if [[ -s ${stdout_log} ]]; then
@@ -201,20 +201,20 @@ trap cleanup EXIT SIGHUP SIGINT SIGTERM
 # Job-specific setup
 
 echo "Running setup..."
-mkdir -p "$home/output"
+mkdir -p "${home}/output"
 eval "${SETUP_COMMANDS}"
 
 echo "Downloading input archive..."
-s3cmd get -r "s3://${BUCKET_NAME}/job-${JOB_ID}/input.zip" "$home/"
-if [[ ! -s "$home/input.zip" ]]; then
+s3cmd get -r "s3://${BUCKET_NAME}/job-${JOB_ID}/input.zip" "${home}/"
+if [[ ! -s "${home}/input.zip" ]]; then
 	echo "Error: Failed to download input archive"
 	exit 1
 fi
 
 echo "Unzipping input archive..."
-unzip "$home/input.zip" -d "$home/"
+unzip "${home}/input.zip" -d "${home}/"
 
-source "$home/venv/bin/activate"
+source "${home}/venv/bin/activate"
 
 # Update state to running
 update_state "running"
@@ -226,7 +226,7 @@ exit_code_flag="/tmp/cloudexec-exit-code"
 # Execute Job
 
 # Use Ctrl-C to detach from the tmux session
-echo "bind-key -n C-c detach" > "$home/.tmux.conf"
+echo "bind-key -n C-c detach" >"${home}/.tmux.conf"
 # Run the tmux command in the background
 echo "Attach to the tmux session with 'cloudexec attach'"
 tmux_session="cloudexec"
@@ -234,7 +234,8 @@ wrapped_run_command="$(
 	cat <<-EOF
 		set_exit_code() { echo \$? > ${exit_code_flag}; };
 		trap set_exit_code EXIT;
-    cd $home/${INPUT_DIRECTORY}
+		    cd ${home}/${INPUT_DIRECTORY}
+		    echo running workload from: ${home}/${INPUT_DIRECTORY}
 		( ${RUN_COMMAND} ) > >(tee -a ${stdout_log}) 2> >(tee -a ${stderr_log} >&2);
 	EOF
 )"

--- a/cmd/cloudexec/user_data.sh.tmpl
+++ b/cmd/cloudexec/user_data.sh.tmpl
@@ -15,9 +15,11 @@ export AWS_DEFAULT_REGION={{.SpacesRegion}}
 export SETUP_COMMANDS="{{.SetupCommands}}"
 export RUN_COMMAND="{{.RunCommand}}"
 export TIMEOUT="{{.Timeout}}"
+export INPUT_DIRECTORY="{{.InputDirectory}}"
 
 stdout_log="/tmp/cloudexec-stdout.log"
 stderr_log="/tmp/cloudexec-stderr.log"
+home="/root"
 
 ########################################
 # Required setup
@@ -126,12 +128,12 @@ cleanup() {
 		update_state "failed"
 	fi
 
-	output_files="$(ls -A ~/output/)"
+	output_files="$(ls -A "$home/output/")"
 	if [[ -n ${output_files} ]]; then
 		echo "Uploading results..."
-		s3cmd put -r ~/output/* "s3://${BUCKET_NAME}/job-${JOB_ID}/output/"
+		s3cmd put -r "$home/output/*" "s3://${BUCKET_NAME}/job-${JOB_ID}/output/"
 	else
-		echo "Skipping results upload, no files found in ~/ouput"
+		echo "Skipping results upload, no files found in $home/ouput"
 	fi
 
 	if [[ -s ${stdout_log} ]]; then
@@ -199,24 +201,20 @@ trap cleanup EXIT SIGHUP SIGINT SIGTERM
 # Job-specific setup
 
 echo "Running setup..."
-mkdir -p ~/output
+mkdir -p "$home/output"
 eval "${SETUP_COMMANDS}"
 
 echo "Downloading input archive..."
-s3cmd get -r "s3://${BUCKET_NAME}/job-${JOB_ID}/input.zip" ~/
-if [[ ! -s ~/input.zip ]]; then
+s3cmd get -r "s3://${BUCKET_NAME}/job-${JOB_ID}/input.zip" "$home/"
+if [[ ! -s "$home/input.zip" ]]; then
 	echo "Error: Failed to download input archive"
 	exit 1
 fi
 
 echo "Unzipping input archive..."
-unzip ~/input.zip -d ~/
-if [[ ! -d ~/input ]]; then
-	echo "Error: Failed to unzip inputs directory"
-	exit 1
-fi
+unzip "$home/input.zip" -d "$home/"
 
-source ~/venv/bin/activate
+source "$home/venv/bin/activate"
 
 # Update state to running
 update_state "running"
@@ -228,7 +226,7 @@ exit_code_flag="/tmp/cloudexec-exit-code"
 # Execute Job
 
 # Use Ctrl-C to detach from the tmux session
-echo "bind-key -n C-c detach" >~/.tmux.conf
+echo "bind-key -n C-c detach" > "$home/.tmux.conf"
 # Run the tmux command in the background
 echo "Attach to the tmux session with 'cloudexec attach'"
 tmux_session="cloudexec"
@@ -236,6 +234,7 @@ wrapped_run_command="$(
 	cat <<-EOF
 		set_exit_code() { echo \$? > ${exit_code_flag}; };
 		trap set_exit_code EXIT;
+    cd $home/${INPUT_DIRECTORY}
 		( ${RUN_COMMAND} ) > >(tee -a ${stdout_log}) 2> >(tee -a ${stderr_log} >&2);
 	EOF
 )"

--- a/example/cloudexec.toml
+++ b/example/cloudexec.toml
@@ -49,4 +49,4 @@ if ! command -v docker >/dev/null 2>&1; then
 '''
 
 # This command is run after the setup script completes.
-run = "cd ~/input && medusa fuzz --target archive.zip"
+run = "medusa fuzz --target archive.zip"


### PR DESCRIPTION
resolves #14 

`cd`s into the input directory before running the workload command so the user doesn't need to remember to do this manually.


<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- New Feature: Added the ability to specify an input directory for running workload commands. The application will automatically change to this directory before executing the command, simplifying user workflow.
- Refactor: Updated file paths for output files and logs to use absolute paths instead of shorthand, improving consistency and reducing potential errors.
- New Feature: Enhanced script functionality to create the output directory under the user's home directory and handle the downloading and unzipping of the input archive into the specified input directory.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->