### PR TITLE
fix droplet cleanup bug

### DIFF
--- a/cmd/cloudexec/clean.go
+++ b/cmd/cloudexec/clean.go
@@ -12,11 +12,11 @@ import (
 func ConfirmDeleteDroplets(config config.Config, dropletName string, instanceToJobs map[int64][]int64) error {
 	instances, err := do.GetDropletsByName(config, dropletName)
 	if err != nil {
-		return fmt.Errorf("Failed to get droplet by name: %w", err)
+		return fmt.Errorf("Failed to get droplets by name: %w", err)
 	}
 	if len(instances) > 0 {
 		// TODO: support multiple droplets
-		fmt.Println("existing instance(s) found:")
+		fmt.Printf("Existing %s instance(s) found:\n", dropletName)
 		for _, instance := range instances {
 			// get a pretty string describing the jobs associated with this instance
 			if instanceToJobs == nil {
@@ -47,7 +47,7 @@ func ConfirmDeleteDroplets(config config.Config, dropletName string, instanceToJ
 			}
 		}
 	} else {
-		fmt.Println("zero instances found")
+		fmt.Printf("Zero %s instances found\n", dropletName)
 	}
 	return nil
 }

--- a/cmd/cloudexec/clean.go
+++ b/cmd/cloudexec/clean.go
@@ -15,7 +15,6 @@ func ConfirmDeleteDroplets(config config.Config, dropletName string, instanceToJ
 		return fmt.Errorf("Failed to get droplets by name: %w", err)
 	}
 	if len(instances) > 0 {
-		// TODO: support multiple droplets
 		fmt.Printf("Existing %s instance(s) found:\n", dropletName)
 		for _, instance := range instances {
 			// get a pretty string describing the jobs associated with this instance

--- a/cmd/cloudexec/launch.go
+++ b/cmd/cloudexec/launch.go
@@ -168,7 +168,6 @@ func Launch(user *user.User, config config.Config, dropletSize string, dropletRe
 	}
 
 	// Add the droplet to the SSH config file
-	// TODO: improve this for multi droplet support
 	fmt.Println("Deleting old cloudexec instance from SSH config file...")
 	err = ssh.DeleteSSHConfig(user, "cloudexec")
 	if err != nil {
@@ -182,7 +181,6 @@ func Launch(user *user.User, config config.Config, dropletSize string, dropletRe
 
 	// Ensure we can SSH into the droplet
 	fmt.Println("Ensuring we can SSH into the droplet...")
-	// TODO: improve this for multi droplet support
 	// sshConfigName := fmt.Sprintf("cloudexec-%v", dropletIp)
 	sshConfigName := "cloudexec"
 	sshConfigName = strings.ReplaceAll(sshConfigName, ".", "-")

--- a/cmd/cloudexec/main.go
+++ b/cmd/cloudexec/main.go
@@ -259,7 +259,7 @@ func main() {
 					if err != nil {
 						return err
 					}
-					err = ConfirmDeleteDroplets(config, username, instanceToJobs)
+					err = ConfirmDeleteDroplets(config, dropletName, instanceToJobs)
 					if err != nil {
 						return err
 					}

--- a/cmd/cloudexec/user_data.sh.tmpl
+++ b/cmd/cloudexec/user_data.sh.tmpl
@@ -238,8 +238,12 @@ wrapped_run_command="$(
 	cat <<-EOF
 		set_exit_code() { echo \$? > ${exit_code_flag}; };
 		trap set_exit_code EXIT;
-		    cd ${home}/${INPUT_DIRECTORY}
-		    echo running workload from: ${home}/${INPUT_DIRECTORY}
+		cd ${home}/${INPUT_DIRECTORY}
+		echo running workload from: ${home}/${INPUT_DIRECTORY}
+		# Activates foundry, etc installations
+		if [[ -f /.bashrc ]]
+		then source /.bashrc
+		fi
 		( ${RUN_COMMAND} ) > >(tee -a ${stdout_log}) 2> >(tee -a ${stderr_log} >&2);
 	EOF
 )"

--- a/cmd/cloudexec/user_data.sh.tmpl
+++ b/cmd/cloudexec/user_data.sh.tmpl
@@ -17,9 +17,11 @@ export RUN_COMMAND="{{.RunCommand}}"
 export TIMEOUT="{{.Timeout}}"
 export INPUT_DIRECTORY="{{.InputDirectory}}"
 
+home="/root"
+input_dir="${home}/${INPUT_DIRECTORY}"
+output_dir="${input_dir}/output"
 stdout_log="/tmp/cloudexec-stdout.log"
 stderr_log="/tmp/cloudexec-stderr.log"
-home="/root"
 
 ########################################
 # Required setup
@@ -128,12 +130,12 @@ cleanup() {
 		update_state "failed"
 	fi
 
-	output_files="$(ls -A "${home}/output/")"
+	output_files="$(ls -A "${output_dir}/")"
 	if [[ -n ${output_files} ]]; then
 		echo "Uploading results..."
-		s3cmd put -r "${home}"/output/* "s3://${BUCKET_NAME}/job-${JOB_ID}/output/"
+		s3cmd put -r "${output_dir}"/* "s3://${BUCKET_NAME}/job-${JOB_ID}/output/"
 	else
-		echo "Skipping results upload, no files found in ${home}/output"
+		echo "Skipping results upload, no files found in ${output_dir}"
 	fi
 
 	if [[ -s ${stdout_log} ]]; then
@@ -201,7 +203,6 @@ trap cleanup EXIT SIGHUP SIGINT SIGTERM
 # Job-specific setup
 
 echo "Running setup..."
-mkdir -p "${home}/output"
 eval "${SETUP_COMMANDS}"
 
 echo "Downloading input archive..."
@@ -213,11 +214,12 @@ fi
 
 echo "Unzipping input archive..."
 unzip "${home}/input.zip" -d "${home}/"
-if [[ ! -d "${home}/${INPUT_DIRECTORY}" ]]; then
-	echo "Error: Failed to unzip required ${INPUT_DIRECTORY} directory"
+if [[ ! -d ${input_dir} ]]; then
+	echo "Error: Failed to unzip required ${input_dir} directory"
 	exit 1
 fi
 
+mkdir -p "${input_dir}/output"
 source "${home}/venv/bin/activate"
 
 # Update state to running
@@ -238,8 +240,8 @@ wrapped_run_command="$(
 	cat <<-EOF
 		set_exit_code() { echo \$? > ${exit_code_flag}; };
 		trap set_exit_code EXIT;
-		cd ${home}/${INPUT_DIRECTORY}
-		echo running workload from: ${home}/${INPUT_DIRECTORY}
+		cd ${input_dir}
+		echo running workload from: ${input_dir}
 		# Activates foundry, etc installations
 		if [[ -f /.bashrc ]]
 		then source /.bashrc

--- a/example/cloudexec.toml
+++ b/example/cloudexec.toml
@@ -45,7 +45,14 @@ if ! command -v docker >/dev/null 2>&1; then
   user="$(whoami)"
   usermod -aG docker "${user}"
   systemctl enable docker
-  fi
+fi
+
+if ! command -v forge >/dev/null 2>&1; then
+  echo "Installing foundry..."
+  curl -L https://foundry.paradigm.xyz | bash
+  source /.bashrc
+  foundryup
+fi
 '''
 
 # This command is run after the setup script completes.

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -211,7 +211,7 @@ func GetJobIdsByInstance(config config.Config, bucketName string) (map[int64][]i
 	}
 	for _, job := range existingState.Jobs {
 		if job.Droplet.ID == 0 {
-      fmt.Printf("Warning: Uninitialized droplet id for job %d\n", job.ID)
+			fmt.Printf("Warning: Uninitialized droplet id for job %d\n", job.ID)
 		}
 		instanceToJobIds[job.Droplet.ID] = append(instanceToJobIds[job.Droplet.ID], job.ID)
 	}

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -211,7 +211,7 @@ func GetJobIdsByInstance(config config.Config, bucketName string) (map[int64][]i
 	}
 	for _, job := range existingState.Jobs {
 		if job.Droplet.ID == 0 {
-			return nil, fmt.Errorf("Uninitialized droplet id for job %d", job.ID)
+      fmt.Printf("Warning: Uninitialized droplet id for job %d\n", job.ID)
 		}
 		instanceToJobIds[job.Droplet.ID] = append(instanceToJobIds[job.Droplet.ID], job.ID)
 	}


### PR DESCRIPTION
Accumulation of tweaks and bug fixes to include in our next patch release.

Fixes:
- naming bug that preventing droplet destruction via `cloudexec clean`



<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Bug Fix: Corrected the `ConfirmDeleteDroplets` function to ensure droplets are properly destroyed when intended.
- Improvement: Updated error handling for uninitialized droplet IDs to display a warning instead of an error, reducing potential confusion.
- Refactor: Streamlined the droplet deletion process by replacing the `username` argument with `dropletName`.
- Improvement: Enhanced the user data script to conditionally source the `.bashrc` file, improving compatibility with different environments.
- Refactor: Cleaned up SSH configuration naming and removed outdated TODO comments for better code clarity.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->