### PR TITLE
Allow manually running a release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,7 @@
 name: Release
 
 on:
+  workflow_dispatch: {}
   push:
     tags:
       - v[0-9].[0-9]+.[0-9]+


### PR DESCRIPTION
Allows manually running a release
<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- New Feature: Added the ability to manually trigger the release process. With the introduction of the `workflow_dispatch` event in our GitHub Actions workflow, users now have the flexibility to initiate a release directly from the GitHub UI. This enhancement provides more control over the release process and facilitates on-demand releases.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->