### PR TITLE
Fix Homebrew Release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,11 +49,6 @@ jobs:
         run: |
           ./dist/cloudexec_linux_amd64_v1/cloudexec version
 
-      - name: Setup SSH Deploy Key
-        uses: webfactory/ssh-agent@d4b9b8ff72958532804b70bbe600ad43b36d5f2e #v0.8.0
-        with:
-          ssh-private-key: ${{ secrets.HOMEBREW_TOOLS_DEPLOY_KEY }}
-
       - name: Publish release
         uses: goreleaser/goreleaser-action@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,4 +54,4 @@ jobs:
           version: latest
           args: release --clean --skip-validate
         env:
-          RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          HOMEBREW_TOOLS_DEPLOY_KEY: ${{ secrets.HOMEBREW_TOOLS_DEPLOY_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,4 +54,4 @@ jobs:
           version: latest
           args: release --clean --skip-validate
         env:
-          RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,3 +60,4 @@ jobs:
           args: release --clean --skip-validate
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PRIVATE_KEY: ${{ secrets.HOMEBREW_TOOLS_DEPLOY_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,8 @@ jobs:
           version: latest
           # Skip the publishing step to test the binaries first
           args: release --skip-publish
+        env:
+          PRIVATE_KEY: ${{ secrets.HOMEBREW_TOOLS_DEPLOY_KEY }}
 
       - name: Verify signatures
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,11 @@ jobs:
         run: |
           ./dist/cloudexec_linux_amd64_v1/cloudexec version
 
+      - name: Setup SSH Deploy Key
+        uses: webfactory/ssh-agent@d4b9b8ff72958532804b70bbe600ad43b36d5f2e #v0.8.0
+        with:
+          ssh-private-key: ${{ secrets.HOMEBREW_TOOLS_DEPLOY_KEY }}
+
       - name: Publish release
         uses: goreleaser/goreleaser-action@v4
         with:
@@ -55,4 +60,3 @@ jobs:
           args: release --clean --skip-validate
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PRIVATE_KEY_PATH: ${{ secrets.HOMEBREW_TOOLS_DEPLOY_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,4 +54,4 @@ jobs:
           version: latest
           args: release --clean --skip-validate
         env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,7 @@
 name: Release
 
 on:
+  workflow_dispatch: {}
   push:
     tags:
       - v[0-9].[0-9]+.[0-9]+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,6 @@
 name: Release
 
 on:
-  workflow_dispatch: {}
   push:
     tags:
       - v[0-9].[0-9]+.[0-9]+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,4 +54,4 @@ jobs:
           version: latest
           args: release --clean --skip-validate
         env:
-          HOMEBREW_TOOLS_DEPLOY_KEY: ${{ secrets.HOMEBREW_TOOLS_DEPLOY_KEY }}
+          RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,4 +54,5 @@ jobs:
           version: latest
           args: release --clean --skip-validate
         env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PRIVATE_KEY_PATH: ${{ secrets.HOMEBREW_TOOLS_DEPLOY_KEY }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -55,7 +55,6 @@ brews:
       name: homebrew-tools
       git:
         url: git@github.com:trailofbits/homebrew-tools.git
-        private_key: "{{ .Env.PRIVATE_KEY_PATH }}"
     homepage: https://github.com/crytic/cloudexec
     folder: Formula
     install: |-

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -43,10 +43,10 @@ signs:
     args: [sign-blob, --yes, "--bundle=${signature}", "${artifact}"]
     artifacts: all
 
-release:
-  github:
-    owner: crytic
-    name: cloudexec
+# release:
+#   github:
+#     owner: crytic
+#     name: cloudexec
 
 brews:
   - tap:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -20,9 +20,7 @@ builds:
     # ensures mod timestamp to be the commit timestamp
     mod_timestamp: "{{ .CommitTimestamp }}"
 
-source:
-  enabled: true
-  rlcp: true
+
 archives:
   - format: tar.gz
     # this name template makes the OS and Arch compatible with the results of uname.
@@ -49,10 +47,10 @@ signs:
 #     name: cloudexec
 
 brews:
-  - tap:
+  - repository:
       owner: trailofbits
       name: homebrew-tools
-      token: "{{ .Env.GITHUB_TOKEN }}"
+      token: "{{ .Env.RELEASE_TOKEN }}"
     homepage: https://github.com/crytic/cloudexec
     folder: Formula
     install: |-

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -49,8 +49,7 @@ brews:
   - repository:
       owner: trailofbits
       name: homebrew-tools
-      git:
-        private_key: "{{ .Env.HOMEBREW_TOOLS_DEPLOY_KEY }}"
+      token: "{{ .Env.RELEASE_TOKEN }}"
     homepage: https://github.com/crytic/cloudexec
     folder: Formula
     install: |-

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -41,10 +41,6 @@ signs:
     artifacts: all
 
 release:
-  # TODO(@oldsj) remove this before merging to main
-  draft: true
-  replace_existing_draft: true
-
   github:
     owner: crytic
     name: cloudexec

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -20,7 +20,6 @@ builds:
     # ensures mod timestamp to be the commit timestamp
     mod_timestamp: "{{ .CommitTimestamp }}"
 
-
 archives:
   - format: tar.gz
     # this name template makes the OS and Arch compatible with the results of uname.

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -55,6 +55,7 @@ brews:
       name: homebrew-tools
       git:
         url: git@github.com:trailofbits/homebrew-tools.git
+        private_key: "{{ .Env.PRIVATE_KEY }}"
     homepage: https://github.com/crytic/cloudexec
     folder: Formula
     install: |-

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -50,7 +50,7 @@ brews:
       owner: trailofbits
       name: homebrew-tools
       git:
-        private_key: '{{ .Env.HOMEBREW_TOOLS_DEPLOY_KEY }}'
+        private_key: "{{ .Env.HOMEBREW_TOOLS_DEPLOY_KEY }}"
     homepage: https://github.com/crytic/cloudexec
     folder: Formula
     install: |-

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -40,16 +40,22 @@ signs:
     args: [sign-blob, --yes, "--bundle=${signature}", "${artifact}"]
     artifacts: all
 
-# release:
-#   github:
-#     owner: crytic
-#     name: cloudexec
+release:
+  # TODO(@oldsj) remove this before merging to main
+  draft: true
+  replace_existing_draft: true
+
+  github:
+    owner: crytic
+    name: cloudexec
 
 brews:
   - repository:
       owner: trailofbits
       name: homebrew-tools
-      token: "{{ .Env.RELEASE_TOKEN }}"
+      git:
+        url: git@github.com:trailofbits/homebrew-tools.git
+        private_key: "{{ .Env.PRIVATE_KEY_PATH }}"
     homepage: https://github.com/crytic/cloudexec
     folder: Formula
     install: |-

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -49,7 +49,8 @@ brews:
   - repository:
       owner: trailofbits
       name: homebrew-tools
-      token: "{{ .Env.RELEASE_TOKEN }}"
+      git:
+        private_key: '{{ .Env.HOMEBREW_TOOLS_DEPLOY_KEY }}'
     homepage: https://github.com/crytic/cloudexec
     folder: Formula
     install: |-

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ cloudexec check
 Generate a cloudexec.toml configuration file in the current directory.
 
 ```bash
-cloudexec launch init
+cloudexec init
 ```
 
 Update the `cloudexec.toml` as needed.


### PR DESCRIPTION
Fixes the homebrew tap publish step of the release.
Once merged and a new release is created, the [`trailofbits/tools`](https://github.com/trailofbits/homebrew-tools) tap will be automatically updated.

I removed the `RELEASE_TOKEN` secret and replaced its use with the default `GITHUB_TOKEN` since that should be able to make a release, and we won't need to manage a personal token.
`HOMEBREW_TOOLS_DEPLOY_KEY` is an SSH deploy key configured at 
 https://github.com/trailofbits/homebrew-tools/settings/keys


<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

---
- **Chore**: Updated GitHub Actions workflow to use `HOMEBREW_TOOLS_DEPLOY_KEY` secret for `PRIVATE_KEY` environment variable and `GITHUB_TOKEN` secret for `GITHUB_TOKEN` environment variable.
- **Refactor**: Modified Homebrew release configuration to replace `source` section with `repository` section, specifying the owner, name, git URL, and private key for the Homebrew repository. This change alters the source of the Homebrew formula.
- **Documentation**: Updated README to reflect a change in command usage from `cloudexec launch init` to `cloudexec init`.
---
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->