### PR TITLE
Pull and clean

### DIFF
--- a/cmd/cloudexec/cancel.go
+++ b/cmd/cloudexec/cancel.go
@@ -9,7 +9,7 @@ import (
 	"github.com/crytic/cloudexec/pkg/state"
 )
 
-func ConfirmCancelJob(config config.Config, existingState *state.State, job *state.Job) error {
+func CancelJob(config config.Config, existingState *state.State, job *state.Job) error {
 	if job.Status != state.Provisioning && job.Status != state.Running {
 		return fmt.Errorf("Job %v is not running, it is %s", job.ID, job.Status)
 	}
@@ -35,7 +35,7 @@ func ConfirmCancelJob(config config.Config, existingState *state.State, job *sta
 	return nil
 }
 
-func ConfirmCancelAll(config config.Config, existingState *state.State) error {
+func CancelAll(config config.Config, existingState *state.State) error {
 	droplets, err := do.GetAllDroplets(config)
 	if err != nil {
 		return fmt.Errorf("Failed to get all running servers: %w", err)
@@ -49,7 +49,7 @@ func ConfirmCancelAll(config config.Config, existingState *state.State) error {
 		if job.Status != state.Provisioning && job.Status != state.Running {
 			continue // skip jobs that aren't running
 		}
-		err = ConfirmCancelJob(config, existingState, &job)
+		err = CancelJob(config, existingState, &job)
 		if err != nil {
 			fmt.Printf("Failed to cancel job %v", job.ID)
 		}

--- a/cmd/cloudexec/cancel.go
+++ b/cmd/cloudexec/cancel.go
@@ -9,33 +9,34 @@ import (
 	"github.com/crytic/cloudexec/pkg/state"
 )
 
-func CancelJob(config config.Config, existingState *state.State, job *state.Job) error {
+func CancelJob(config config.Config, existingState *state.State, job *state.Job, force bool) error {
 	if job.Status != state.Provisioning && job.Status != state.Running {
 		return fmt.Errorf("Job %v is not running, it is %s", job.ID, job.Status)
 	}
-	fmt.Printf("Droplet %s associated with job %v: IP=%v | CreatedAt=%s\n", job.Droplet.Name, job.ID, job.Droplet.IP, job.Droplet.Created)
-	fmt.Println("Destroy this droplet? (y/n)")
-	var response string
-	fmt.Scanln(&response)
-	if strings.ToLower(response) == "y" {
-		fmt.Printf("Destroying droplet %v...\n", job.Droplet.ID)
-		err := do.DeleteDroplet(config, job.Droplet.ID)
-		if err != nil {
-			return fmt.Errorf("Failed to destroy droplet: %w", err)
+	fmt.Printf("Destroying droplet %s associated with job %v: IP=%v | CreatedAt=%s\n", job.Droplet.Name, job.ID, job.Droplet.IP, job.Droplet.Created)
+	if !force { // Ask for confirmation before cleaning this job if no force flag
+		fmt.Println("Confirm? (y/n)")
+		var response string
+		fmt.Scanln(&response)
+		if strings.ToLower(response) != "y" {
+			fmt.Printf("Droplet %s was not destroyed\n", job.Droplet.Name)
+			return nil
 		}
-		fmt.Printf("Marking job %v as cancelled...\n", job.Droplet.ID)
-		err = existingState.CancelRunningJob(config, job.ID)
-		if err != nil {
-			return fmt.Errorf("Failed to mark job as cancelled: %w", err)
-		}
-		fmt.Println("Done")
-	} else {
-		fmt.Printf("Job %v was not cancelled\n", job.ID)
+	}
+	fmt.Printf("Destroying droplet %v...\n", job.Droplet.ID)
+	err := do.DeleteDroplet(config, job.Droplet.ID)
+	if err != nil {
+		return fmt.Errorf("Failed to destroy droplet: %w", err)
+	}
+	fmt.Printf("Marking job %v as cancelled...\n", job.Droplet.ID)
+	err = existingState.CancelRunningJob(config, job.ID)
+	if err != nil {
+		return fmt.Errorf("Failed to mark job as cancelled: %w", err)
 	}
 	return nil
 }
 
-func CancelAll(config config.Config, existingState *state.State) error {
+func CancelAll(config config.Config, existingState *state.State, force bool) error {
 	droplets, err := do.GetAllDroplets(config)
 	if err != nil {
 		return fmt.Errorf("Failed to get all running servers: %w", err)
@@ -49,7 +50,7 @@ func CancelAll(config config.Config, existingState *state.State) error {
 		if job.Status != state.Provisioning && job.Status != state.Running {
 			continue // skip jobs that aren't running
 		}
-		err = CancelJob(config, existingState, &job)
+		err = CancelJob(config, existingState, &job, force)
 		if err != nil {
 			fmt.Printf("Failed to cancel job %v", job.ID)
 		}

--- a/cmd/cloudexec/cancel.go
+++ b/cmd/cloudexec/cancel.go
@@ -10,7 +10,7 @@ import (
 	"github.com/crytic/cloudexec/pkg/state"
 )
 
-func ConfirmCancelJob(job *state.Job, existingState *state.State, config config.Config) error {
+func ConfirmCancelJob(config config.Config, existingState *state.State, job *state.Job) error {
 	if job.Status != state.Provisioning && job.Status != state.Running {
 		return fmt.Errorf("Job %v is not running, it is %s", job.ID, job.Status)
 	}
@@ -55,7 +55,7 @@ func ConfirmCancelAll(config config.Config, existingState *state.State) error {
 		if job.Status != state.Provisioning && job.Status != state.Running {
 			continue // skip jobs that aren't running
 		}
-		err = ConfirmCancelJob(&job, existingState, config)
+		err = ConfirmCancelJob(config, existingState, &job)
 		if err != nil {
 			fmt.Printf("Failed to cancel job %v", job.ID)
 		}

--- a/cmd/cloudexec/cancel.go
+++ b/cmd/cloudexec/cancel.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/crytic/cloudexec/pkg/config"
 	do "github.com/crytic/cloudexec/pkg/digitalocean"
-	"github.com/crytic/cloudexec/pkg/ssh"
 	"github.com/crytic/cloudexec/pkg/state"
 )
 
@@ -23,11 +22,6 @@ func ConfirmCancelJob(config config.Config, existingState *state.State, job *sta
 		err := do.DeleteDroplet(config, job.Droplet.ID)
 		if err != nil {
 			return fmt.Errorf("Failed to destroy droplet: %w", err)
-		}
-		fmt.Printf("Removing ssh config for droplet %v...\n", job.Droplet.ID)
-		err = ssh.DeleteSSHConfig(job.ID)
-		if err != nil {
-			return fmt.Errorf("Failed to delete ssh config: %w", err)
 		}
 		fmt.Printf("Marking job %v as cancelled...\n", job.Droplet.ID)
 		err = existingState.CancelRunningJob(config, job.ID)

--- a/cmd/cloudexec/clean.go
+++ b/cmd/cloudexec/clean.go
@@ -37,21 +37,21 @@ func CleanBucketJob(config config.Config, existingState *state.State, jobID int6
 				}
 			}
 			fmt.Printf("Deleted %d objects from bucket, removing job %v from state file..\n", numToRm, jobID)
-      newState := &state.State{}
-      deleteJob := state.Job{
-        ID:     jobID,
-        Delete: true,
-      }
-      newState.CreateJob(deleteJob)
-      err = state.MergeAndSave(config, newState)
-      if err != nil {
-        return fmt.Errorf("Error removing %s from state file: %w\n", prefix, err)
-      }
-      fmt.Printf("Removing ssh config for job %v...\n", jobID)
-      err = ssh.DeleteSSHConfig(jobID)
-      if err != nil {
-        return fmt.Errorf("Failed to delete ssh config: %w", err)
-      }
+			newState := &state.State{}
+			deleteJob := state.Job{
+				ID:     jobID,
+				Delete: true,
+			}
+			newState.CreateJob(deleteJob)
+			err = state.MergeAndSave(config, newState)
+			if err != nil {
+				return fmt.Errorf("Error removing %s from state file: %w\n", prefix, err)
+			}
+			fmt.Printf("Removing ssh config for job %v...\n", jobID)
+			err = ssh.DeleteSSHConfig(jobID)
+			if err != nil {
+				return fmt.Errorf("Failed to delete ssh config: %w", err)
+			}
 		}
 	}
 	return nil

--- a/cmd/cloudexec/clean.go
+++ b/cmd/cloudexec/clean.go
@@ -6,16 +6,16 @@ import (
 
 	"github.com/crytic/cloudexec/pkg/config"
 	"github.com/crytic/cloudexec/pkg/s3"
-	// "github.com/crytic/cloudexec/pkg/state"
+	"github.com/crytic/cloudexec/pkg/state"
 )
 
-func CleanBucketJob(config config.Config, jobID int64) error {
+func CleanBucketJob(config config.Config, existingState *state.State, jobID int64) error {
 	prefix := fmt.Sprintf("job-%v", jobID)
 	objects, err := s3.ListObjects(config, prefix)
 	if err != nil {
 		return fmt.Errorf("Failed to list objects in bucket with prefix %s: %w", prefix, err)
 	}
-	// Confirm bucket deletion
+	// Confirm job data deletion
 	var numToRm int = len(objects)
 	if numToRm == 0 {
 		fmt.Printf("Bucket is already empty.\n")
@@ -36,37 +36,21 @@ func CleanBucketJob(config config.Config, jobID int64) error {
 				}
 			}
 			fmt.Printf("Deleted %d objects from bucket...\n", numToRm)
+			existingState.DeleteJob(jobID)
+			err = state.UpdateState(config, existingState)
+			if err != nil {
+				return fmt.Errorf("Error removing %s from state file: %w\n", prefix, err)
+			}
 		}
 	}
 	return nil
 }
 
-func CleanBucketAll(config config.Config) error {
-	objects, err := s3.ListObjects(config, "")
-	if err != nil {
-		return fmt.Errorf("Failed to list objects in bucket: %w", err)
-	}
-	// Confirm bucket deletion
-	var numToRm int = len(objects)
-	if numToRm == 0 {
-		fmt.Printf("Bucket is already empty.\n")
-		return nil
-	} else {
-		fmt.Printf("Removing the first %d items from bucket...\n", numToRm)
-		fmt.Println("Confirm? (y/n)")
-		var response string
-		fmt.Scanln(&response)
-		if strings.ToLower(response) == "y" {
-			fmt.Printf("Deleting bucket contents...\n")
-			// Delete all objects in the bucket
-			for _, object := range objects {
-				fmt.Println("Deleting object: ", object)
-				err = s3.DeleteObject(config, object)
-				if err != nil {
-					return err
-				}
-			}
-			fmt.Printf("Deleted %d objects from bucket...\n", numToRm)
+func CleanBucketAll(config config.Config, existingState *state.State) error {
+	for _, job := range existingState.Jobs {
+		err := CleanBucketJob(config, existingState, job.ID)
+		if err != nil {
+			return err
 		}
 	}
 	return nil

--- a/cmd/cloudexec/clean.go
+++ b/cmd/cloudexec/clean.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/crytic/cloudexec/pkg/config"
 	"github.com/crytic/cloudexec/pkg/s3"
+	"github.com/crytic/cloudexec/pkg/ssh"
 	"github.com/crytic/cloudexec/pkg/state"
 )
 
@@ -45,6 +46,11 @@ func CleanBucketJob(config config.Config, existingState *state.State, jobID int6
       err = state.MergeAndSave(config, newState)
       if err != nil {
         return fmt.Errorf("Error removing %s from state file: %w\n", prefix, err)
+      }
+      fmt.Printf("Removing ssh config for job %v...\n", jobID)
+      err = ssh.DeleteSSHConfig(jobID)
+      if err != nil {
+        return fmt.Errorf("Failed to delete ssh config: %w", err)
       }
 		}
 	}

--- a/cmd/cloudexec/clean.go
+++ b/cmd/cloudexec/clean.go
@@ -5,39 +5,47 @@ import (
 	"strings"
 
 	"github.com/crytic/cloudexec/pkg/config"
-	do "github.com/crytic/cloudexec/pkg/digitalocean"
 	"github.com/crytic/cloudexec/pkg/s3"
-	"github.com/crytic/cloudexec/pkg/state"
+	// "github.com/crytic/cloudexec/pkg/state"
 )
 
-func ConfirmCancelAll(config config.Config, existingState *state.State) error {
-	droplets, err := do.GetAllDroplets(config)
+func CleanBucketJob(config config.Config, jobID int64) error {
+	prefix := fmt.Sprintf("job-%v", jobID)
+	objects, err := s3.ListObjects(config, prefix)
 	if err != nil {
-		return fmt.Errorf("Failed to get all running servers: %w", err)
+		return fmt.Errorf("Failed to list objects in bucket with prefix %s: %w", prefix, err)
 	}
-	if len(droplets) == 0 {
-		fmt.Printf("Zero servers found\n")
+	// Confirm bucket deletion
+	var numToRm int = len(objects)
+	if numToRm == 0 {
+		fmt.Printf("Bucket is already empty.\n")
 		return nil
-	}
-	fmt.Printf("Found %v running server(s):\n", len(droplets))
-	for _, job := range existingState.Jobs {
-		if job.Status != state.Provisioning && job.Status != state.Running {
-			continue // skip jobs that aren't running
-		}
-		err = CancelJob(&job, existingState, config)
-		if err != nil {
-			fmt.Printf("Failed to cancel job %v", job.ID)
+	} else {
+		fmt.Printf("Removing ALL input, output, and logs associated with %s...\n", prefix)
+		fmt.Println("Confirm? (y/n)")
+		var response string
+		fmt.Scanln(&response)
+		if strings.ToLower(response) == "y" {
+			fmt.Printf("Deleting bucket contents...\n")
+			// Delete all objects in the bucket
+			for _, object := range objects {
+				fmt.Println("Deleting object: ", object)
+				err = s3.DeleteObject(config, object)
+				if err != nil {
+					return err
+				}
+			}
+			fmt.Printf("Deleted %d objects from bucket...\n", numToRm)
 		}
 	}
 	return nil
 }
 
-func ResetBucket(config config.Config) error {
+func CleanBucketAll(config config.Config) error {
 	objects, err := s3.ListObjects(config, "")
 	if err != nil {
 		return fmt.Errorf("Failed to list objects in bucket: %w", err)
 	}
-
 	// Confirm bucket deletion
 	var numToRm int = len(objects)
 	if numToRm == 0 {

--- a/cmd/cloudexec/clean.go
+++ b/cmd/cloudexec/clean.go
@@ -10,7 +10,7 @@ import (
 	"github.com/crytic/cloudexec/pkg/state"
 )
 
-func CleanBucketJob(config config.Config, existingState *state.State, jobID int64) error {
+func CleanBucketJob(config config.Config, existingState *state.State, jobID int64, force bool) error {
 	prefix := fmt.Sprintf("job-%v", jobID)
 	objects, err := s3.ListObjects(config, prefix)
 	if err != nil {
@@ -21,49 +21,52 @@ func CleanBucketJob(config config.Config, existingState *state.State, jobID int6
 	if numToRm == 0 {
 		fmt.Printf("Bucket is already empty.\n")
 		return nil
-	} else {
-		fmt.Printf("Removing ALL input, output, and logs associated with %s...\n", prefix)
+	}
+	fmt.Printf("Removing ALL input, output, and logs associated with %s...\n", prefix)
+	if !force { // Ask for confirmation before cleaning this job if no force flag
 		fmt.Println("Confirm? (y/n)")
 		var response string
 		fmt.Scanln(&response)
-		if strings.ToLower(response) == "y" {
-			fmt.Printf("Deleting bucket contents...\n")
-			// Delete all objects in the bucket
-			for _, object := range objects {
-				fmt.Println("Deleting object: ", object)
-				err = s3.DeleteObject(config, object)
-				if err != nil {
-					return err
-				}
-			}
-			fmt.Printf("Deleted %d objects from bucket, removing job %v from state file..\n", numToRm, jobID)
-			newState := &state.State{}
-			deleteJob := state.Job{
-				ID:     jobID,
-				Delete: true,
-			}
-			newState.CreateJob(deleteJob)
-			err = state.MergeAndSave(config, newState)
-			if err != nil {
-				return fmt.Errorf("Error removing %s from state file: %w\n", prefix, err)
-			}
-			fmt.Printf("Removing ssh config for job %v...\n", jobID)
-			err = ssh.DeleteSSHConfig(jobID)
-			if err != nil {
-				return fmt.Errorf("Failed to delete ssh config: %w", err)
-			}
+		if strings.ToLower(response) != "y" {
+			fmt.Printf("Job %v was not cleaned\n", jobID)
+			return nil
 		}
+	}
+	fmt.Printf("Deleting bucket contents...\n")
+	// Delete all objects in the bucket
+	for _, object := range objects {
+		fmt.Println("Deleting object: ", object)
+		err = s3.DeleteObject(config, object)
+		if err != nil {
+			return err
+		}
+	}
+	fmt.Printf("Deleted %d objects from bucket, removing job %v from state file..\n", numToRm, jobID)
+	newState := &state.State{}
+	deleteJob := state.Job{
+		ID:     jobID,
+		Delete: true,
+	}
+	newState.CreateJob(deleteJob)
+	err = state.MergeAndSave(config, newState)
+	if err != nil {
+		return fmt.Errorf("Error removing %s from state file: %w\n", prefix, err)
+	}
+	fmt.Printf("Removing ssh config for job %v...\n", jobID)
+	err = ssh.DeleteSSHConfig(jobID)
+	if err != nil {
+		return fmt.Errorf("Failed to delete ssh config: %w", err)
 	}
 	return nil
 }
 
-func CleanBucketAll(config config.Config, existingState *state.State) error {
-  if len(existingState.Jobs) == 0 {
-    fmt.Println("No jobs found")
-    return nil
-  }
+func CleanBucketAll(config config.Config, existingState *state.State, force bool) error {
+	if len(existingState.Jobs) == 0 {
+		fmt.Println("No jobs are available")
+		return nil
+	}
 	for _, job := range existingState.Jobs {
-		err := CleanBucketJob(config, existingState, job.ID)
+		err := CleanBucketJob(config, existingState, job.ID, force)
 		if err != nil {
 			return err
 		}

--- a/cmd/cloudexec/clean.go
+++ b/cmd/cloudexec/clean.go
@@ -58,6 +58,10 @@ func CleanBucketJob(config config.Config, existingState *state.State, jobID int6
 }
 
 func CleanBucketAll(config config.Config, existingState *state.State) error {
+  if len(existingState.Jobs) == 0 {
+    fmt.Println("No jobs found")
+    return nil
+  }
 	for _, job := range existingState.Jobs {
 		err := CleanBucketJob(config, existingState, job.ID)
 		if err != nil {

--- a/cmd/cloudexec/clean.go
+++ b/cmd/cloudexec/clean.go
@@ -35,12 +35,17 @@ func CleanBucketJob(config config.Config, existingState *state.State, jobID int6
 					return err
 				}
 			}
-			fmt.Printf("Deleted %d objects from bucket...\n", numToRm)
-			existingState.DeleteJob(jobID)
-			err = state.UpdateState(config, existingState)
-			if err != nil {
-				return fmt.Errorf("Error removing %s from state file: %w\n", prefix, err)
-			}
+			fmt.Printf("Deleted %d objects from bucket, removing job %v from state file..\n", numToRm, jobID)
+      newState := &state.State{}
+      deleteJob := state.Job{
+        ID:     jobID,
+        Delete: true,
+      }
+      newState.CreateJob(deleteJob)
+      err = state.MergeAndSave(config, newState)
+      if err != nil {
+        return fmt.Errorf("Error removing %s from state file: %w\n", prefix, err)
+      }
 		}
 	}
 	return nil

--- a/cmd/cloudexec/launch.go
+++ b/cmd/cloudexec/launch.go
@@ -115,7 +115,7 @@ func Launch(config config.Config, dropletSize string, dropletRegion string, lc L
 	newState.CreateJob(newJob)
 	// sync state to bucket
 	fmt.Printf("Adding new job to the state...\n")
-	err = state.UpdateState(config, newState)
+	err = state.MergeAndSave(config, newState)
 	if err != nil {
 		return fmt.Errorf("Failed to update S3 state: %w", err)
 	}
@@ -161,7 +161,7 @@ func Launch(config config.Config, dropletSize string, dropletRegion string, lc L
 		}
 	}
 	fmt.Printf("Uploading new state to %s\n", bucketName)
-	err = state.UpdateState(config, newState)
+	err = state.MergeAndSave(config, newState)
 	if err != nil {
 		return fmt.Errorf("Failed to update S3 state: %w", err)
 	}

--- a/cmd/cloudexec/main.go
+++ b/cmd/cloudexec/main.go
@@ -325,7 +325,7 @@ func main() {
 					} else {
 						targetJob = existingState.GetJob(jobID)
 					}
-					err = CancelJob(targetJob, existingState, config)
+					err = ConfirmCancelJob(targetJob, existingState, config)
 					if err != nil {
 						return err
 					}
@@ -336,7 +336,14 @@ func main() {
 			{
 				Name:  "clean",
 				Usage: "Cleans up any running cloudexec droplets and clears the spaces bucket",
-				Action: func(*cli.Context) error {
+				Flags: []cli.Flag{
+					&cli.IntFlag{
+						Name:  "job",
+						Value: 0,
+						Usage: "Optional job ID to get logs from",
+					},
+				},
+				Action: func(c *cli.Context) error {
 					if configErr != nil {
 						return configErr // Abort on configuration error
 					}
@@ -348,14 +355,21 @@ func main() {
 					if err != nil {
 						return err
 					}
-					err = ConfirmCancelAll(config, existingState)
-					if err != nil {
-						return err
-					}
-					// clean existing files from the bucket
-					err = ResetBucket(config)
-					if err != nil {
-						return err
+					jobID := c.Int64("job")
+					// var targetJob *state.Job
+					if jobID == 0 { // If no job provided, clean everything
+						err = ConfirmCancelAll(config, existingState)
+						if err != nil {
+							return err
+						}
+						// clean existing files from the bucket
+						err = CleanBucketAll(config)
+						if err != nil {
+							return err
+						}
+						// } else {
+						// 	targetJob = existingState.GetJob(jobID)
+						// TODO
 					}
 					return nil
 				},

--- a/cmd/cloudexec/main.go
+++ b/cmd/cloudexec/main.go
@@ -198,14 +198,14 @@ func main() {
 						if err != nil {
 							return err
 						}
-            jobID = latestCompletedJob.ID
+						jobID = latestCompletedJob.ID
 					}
-          path := c.String("path")
-          if path == "" {
-            path = fmt.Sprintf("cloudexec-%v", jobID)
-          }
-          err = DownloadJobOutput(config, jobID, path)
-          return err
+					path := c.String("path")
+					if path == "" {
+						path = fmt.Sprintf("cloudexec-%v", jobID)
+					}
+					err = DownloadJobOutput(config, jobID, path)
+					return err
 				},
 			},
 
@@ -240,9 +240,9 @@ func main() {
 						jobID = targetJob.ID
 					} else {
 						targetJob = existingState.GetJob(jobID)
-            if targetJob == nil {
-              return fmt.Errorf("Job %v does not exist", jobID)
-            }
+						if targetJob == nil {
+							return fmt.Errorf("Job %v does not exist", jobID)
+						}
 					}
 					// If the target job is running, stream logs
 					jobStatus := targetJob.Status
@@ -323,9 +323,9 @@ func main() {
 						targetJob = existingState.GetLatestJob()
 					} else {
 						targetJob = existingState.GetJob(jobID)
-            if targetJob == nil {
-              return fmt.Errorf("Job %v does not exist", jobID)
-            }
+						if targetJob == nil {
+							return fmt.Errorf("Job %v does not exist", jobID)
+						}
 					}
 					err = ConfirmCancelJob(config, existingState, targetJob)
 					if err != nil {
@@ -371,9 +371,9 @@ func main() {
 						}
 					} else {
 						targetJob := existingState.GetJob(jobID)
-            if targetJob == nil {
-              return fmt.Errorf("Job %v does not exist", jobID)
-            }
+						if targetJob == nil {
+							return fmt.Errorf("Job %v does not exist", jobID)
+						}
 						// Cancel servers associated with this job if they're running
 						if targetJob.Status == state.Provisioning || targetJob.Status == state.Running {
 							err = ConfirmCancelJob(config, existingState, targetJob)
@@ -424,14 +424,14 @@ func main() {
 						jobID = targetJob.ID
 					} else {
 						targetJob = existingState.GetJob(jobID)
-						if err != nil {
-							return err
+						if targetJob == nil {
+							return fmt.Errorf("Job %v does not exist", jobID)
 						}
-          }
-          path := c.String("path")
-          if path == "" {
-            path = fmt.Sprintf("cloudexec-%v", jobID)
-          }
+					}
+					path := c.String("path")
+					if path == "" {
+						path = fmt.Sprintf("cloudexec-%v", jobID)
+					}
 					// Pull all data
 					err = DownloadJobOutput(config, jobID, path)
 					if err != nil {

--- a/cmd/cloudexec/main.go
+++ b/cmd/cloudexec/main.go
@@ -425,13 +425,18 @@ func main() {
 					// If no job id provided, use latest completed job
 					jobID := c.Int64("job")
 					var targetJob *state.Job
-					if c.Int("job") != 0 {
-						targetJob, err := state.GetLatestCompletedJob(existingState)
+					if c.Int("job") == 0 {
+						targetJob, err = state.GetLatestCompletedJob(existingState)
 						if err != nil {
 							return err
 						}
 						jobID = targetJob.ID
-					}
+					} else {
+						targetJob = existingState.GetJob(jobID)
+						if err != nil {
+							return err
+						}
+          }
 					// Pull all data
 					err = DownloadJobOutput(config, jobID, path)
 					if err != nil {

--- a/cmd/cloudexec/main.go
+++ b/cmd/cloudexec/main.go
@@ -245,6 +245,9 @@ func main() {
 						jobID = targetJob.ID
 					} else {
 						targetJob = existingState.GetJob(jobID)
+            if targetJob == nil {
+              return fmt.Errorf("Job %v does not exist", jobID)
+            }
 					}
 					// If the target job is running, stream logs
 					jobStatus := targetJob.Status
@@ -325,6 +328,9 @@ func main() {
 						targetJob = existingState.GetLatestJob()
 					} else {
 						targetJob = existingState.GetJob(jobID)
+            if targetJob == nil {
+              return fmt.Errorf("Job %v does not exist", jobID)
+            }
 					}
 					err = ConfirmCancelJob(config, existingState, targetJob)
 					if err != nil {
@@ -370,6 +376,9 @@ func main() {
 						}
 					} else {
 						targetJob := existingState.GetJob(jobID)
+            if targetJob == nil {
+              return fmt.Errorf("Job %v does not exist", jobID)
+            }
 						// Cancel servers associated with this job if they're running
 						if targetJob.Status == state.Provisioning || targetJob.Status == state.Running {
 							err = ConfirmCancelJob(config, existingState, targetJob)
@@ -498,7 +507,7 @@ func main() {
 								Delete: true,
 							}
 							newState.CreateJob(deleteJob)
-							err = state.UpdateState(config, newState)
+							err = state.MergeAndSave(config, newState)
 							if err != nil {
 								return err
 							}

--- a/cmd/cloudexec/pull.go
+++ b/cmd/cloudexec/pull.go
@@ -11,16 +11,8 @@ import (
 )
 
 func DownloadJobOutput(config config.Config, jobID int64, localPath string) error {
+
 	bucketPrefix := fmt.Sprintf("job-%v/output", jobID)
-
-	// Check if the local path is a directory, if not, create it
-	if _, err := os.Stat(localPath); os.IsNotExist(err) {
-		err = os.MkdirAll(localPath, 0755)
-		if err != nil {
-			return fmt.Errorf("Failed to create local directory at %s: %w", localPath, err)
-		}
-	}
-
 	objectKeys, err := s3.ListObjects(config, bucketPrefix)
 	if err != nil {
 		return fmt.Errorf("Failed to list bucket objects: %w", err)
@@ -63,5 +55,43 @@ func DownloadJobOutput(config config.Config, jobID int64, localPath string) erro
 		return nil
 	}
 
-	return downloadObjects(objectKeys, bucketPrefix)
+  // Add the logs to the output dir
+  body, logErr := s3.GetObject(config, fmt.Sprintf("job-%v/cloudexec.log", jobID))
+
+  if len(objectKeys) == 0 && logErr != nil {
+    fmt.Printf("No output or logs are available for job %v\n", jobID)
+    return nil
+  } else if len(objectKeys) == 0 {
+    fmt.Printf("No output is available for job %v\n", jobID)
+  } else if logErr != nil {
+    fmt.Printf("No logs are available for job %v\n", jobID)
+  }
+
+  // Check if the local path is a directory, if not, create it
+  if _, err := os.Stat(localPath); os.IsNotExist(err) {
+    err = os.MkdirAll(localPath, 0755)
+    if err != nil {
+      return fmt.Errorf("Failed to create local directory at %s: %w", localPath, err)
+    }
+  }
+
+  // Download output, if any
+  if len(objectKeys) > 0 {
+    err = downloadObjects(objectKeys, bucketPrefix)
+    if err != nil {
+      return err
+    }
+  }
+
+  // Write logs to file, if available
+  if logErr == nil {
+    localFilePath := filepath.Join(localPath, "cloudexec.log")
+    err = os.WriteFile(localFilePath, body, 0644)
+    if err != nil {
+      return fmt.Errorf("Failed to write object content to file: %w", err)
+    }
+    fmt.Printf("Downloaded job %v logs to %s \n", jobID, localFilePath)
+  }
+
+  return nil
 }

--- a/cmd/cloudexec/pull.go
+++ b/cmd/cloudexec/pull.go
@@ -10,8 +10,8 @@ import (
 	"github.com/crytic/cloudexec/pkg/s3"
 )
 
-func DownloadJobOutput(config config.Config, jobID int, localPath string) error {
-	bucketPrefix := fmt.Sprintf("job-%d/output", jobID)
+func DownloadJobOutput(config config.Config, jobID int64, localPath string) error {
+	bucketPrefix := fmt.Sprintf("job-%v/output", jobID)
 
 	// Check if the local path is a directory, if not, create it
 	if _, err := os.Stat(localPath); os.IsNotExist(err) {

--- a/cmd/cloudexec/pull.go
+++ b/cmd/cloudexec/pull.go
@@ -55,43 +55,43 @@ func DownloadJobOutput(config config.Config, jobID int64, localPath string) erro
 		return nil
 	}
 
-  // Add the logs to the output dir
-  body, logErr := s3.GetObject(config, fmt.Sprintf("job-%v/cloudexec.log", jobID))
+	// Add the logs to the output dir
+	body, logErr := s3.GetObject(config, fmt.Sprintf("job-%v/cloudexec.log", jobID))
 
-  if len(objectKeys) == 0 && logErr != nil {
-    fmt.Printf("No output or logs are available for job %v\n", jobID)
-    return nil
-  } else if len(objectKeys) == 0 {
-    fmt.Printf("No output is available for job %v\n", jobID)
-  } else if logErr != nil {
-    fmt.Printf("No logs are available for job %v\n", jobID)
-  }
+	if len(objectKeys) == 0 && logErr != nil {
+		fmt.Printf("No output or logs are available for job %v\n", jobID)
+		return nil
+	} else if len(objectKeys) == 0 {
+		fmt.Printf("No output is available for job %v\n", jobID)
+	} else if logErr != nil {
+		fmt.Printf("No logs are available for job %v\n", jobID)
+	}
 
-  // Check if the local path is a directory, if not, create it
-  if _, err := os.Stat(localPath); os.IsNotExist(err) {
-    err = os.MkdirAll(localPath, 0755)
-    if err != nil {
-      return fmt.Errorf("Failed to create local directory at %s: %w", localPath, err)
-    }
-  }
+	// Check if the local path is a directory, if not, create it
+	if _, err := os.Stat(localPath); os.IsNotExist(err) {
+		err = os.MkdirAll(localPath, 0755)
+		if err != nil {
+			return fmt.Errorf("Failed to create local directory at %s: %w", localPath, err)
+		}
+	}
 
-  // Download output, if any
-  if len(objectKeys) > 0 {
-    err = downloadObjects(objectKeys, bucketPrefix)
-    if err != nil {
-      return err
-    }
-  }
+	// Download output, if any
+	if len(objectKeys) > 0 {
+		err = downloadObjects(objectKeys, bucketPrefix)
+		if err != nil {
+			return err
+		}
+	}
 
-  // Write logs to file, if available
-  if logErr == nil {
-    localFilePath := filepath.Join(localPath, "cloudexec.log")
-    err = os.WriteFile(localFilePath, body, 0644)
-    if err != nil {
-      return fmt.Errorf("Failed to write object content to file: %w", err)
-    }
-    fmt.Printf("Downloaded job %v logs to %s \n", jobID, localFilePath)
-  }
+	// Write logs to file, if available
+	if logErr == nil {
+		localFilePath := filepath.Join(localPath, "cloudexec.log")
+		err = os.WriteFile(localFilePath, body, 0644)
+		if err != nil {
+			return fmt.Errorf("Failed to write object content to file: %w", err)
+		}
+		fmt.Printf("Downloaded job %v logs to %s \n", jobID, localFilePath)
+	}
 
-  return nil
+	return nil
 }

--- a/cmd/cloudexec/status.go
+++ b/cmd/cloudexec/status.go
@@ -58,13 +58,13 @@ func PrintStatus(config config.Config, showAll bool) error {
 	}
 
 	// Find the latest completed job
-	latestCompletedJob, err := state.GetLatestCompletedJob(existingState)
+	latestJob, err := state.GetLatestJob(existingState)
 	if err != nil {
 		return err
 	}
 
 	for _, job := range existingState.Jobs {
-		if showAll || (job.Status == state.Running || job.Status == state.Provisioning) || (latestCompletedJob != nil && job.ID == latestCompletedJob.ID) {
+		if showAll || (job.Status == state.Running || job.Status == state.Provisioning) || (latestJob != nil && job.ID == latestJob.ID) {
 
 			latestUpdate := func() int64 {
 				if job.CompletedAt == 0 {

--- a/cmd/cloudexec/status.go
+++ b/cmd/cloudexec/status.go
@@ -57,11 +57,8 @@ func PrintStatus(config config.Config, showAll bool) error {
 		return strconv.FormatFloat(f, 'f', 4, 64)
 	}
 
-	// Find the latest completed job
-	latestJob, err := state.GetLatestJob(existingState)
-	if err != nil {
-		return err
-	}
+	// Find the latest job to use as the default display
+	latestJob := existingState.GetLatestJob()
 
 	for _, job := range existingState.Jobs {
 		if showAll || (job.Status == state.Running || job.Status == state.Provisioning) || (latestJob != nil && job.ID == latestJob.ID) {

--- a/cmd/cloudexec/user_data.sh.tmpl
+++ b/cmd/cloudexec/user_data.sh.tmpl
@@ -162,7 +162,7 @@ cleanup() {
 
 	if [[ -s "/var/log/cloud-init-output.log" ]]; then
 		echo "Uploading logs..."
-		s3cmd put /var/log/cloud-init-output.log "s3://${BUCKET_NAME}/job-${JOB_ID}/logs/"
+		s3cmd put /var/log/cloud-init-output.log "s3://${BUCKET_NAME}/job-${JOB_ID}/cloudexec.log"
 	else
 		echo "No logs to upload.."
 	fi

--- a/pkg/digitalocean/digitalocean.go
+++ b/pkg/digitalocean/digitalocean.go
@@ -37,7 +37,7 @@ type Snapshot struct {
  * the vps hub, everything related to digital ocean server management
  * exports the following functions:
  * - CheckAuth(config config.Config) (string, error)
- * - CreateDroplet(config config.Config, region string, size string, userData string, jobId int64, publicKey string) (Droplet, error)
+ * - CreateDroplet(config config.Config, region string, size string, userData string, jobID int64, publicKey string) (Droplet, error)
  * - GetAllDroplets(config config.Config) ([]Droplet, error)
  * - DeleteDroplet(config config.Config, dropletID int64) error
  * - GetLatestSnapshot(config config.Config) (Snapshot, error)
@@ -124,7 +124,7 @@ func CheckAuth(config config.Config) (string, error) {
 }
 
 // Launch a new droplet
-func CreateDroplet(config config.Config, region string, size string, userData string, jobId int64, publicKey string) (Droplet, error) {
+func CreateDroplet(config config.Config, region string, size string, userData string, jobID int64, publicKey string) (Droplet, error) {
 	var droplet Droplet
 	// create a client
 	doClient, err := initializeDOClient(config.DigitalOcean.ApiKey)
@@ -173,7 +173,7 @@ func CreateDroplet(config config.Config, region string, size string, userData st
 		Tags: []string{
 			cloudexecTag,
 			"Owner:" + config.Username,
-			"Job:" + fmt.Sprintf("%v", jobId),
+			"Job:" + fmt.Sprintf("%v", jobID),
 		},
 		// Don't install the droplet agent
 		WithDropletAgent: new(bool),

--- a/pkg/digitalocean/digitalocean.go
+++ b/pkg/digitalocean/digitalocean.go
@@ -132,9 +132,11 @@ func CreateDroplet(config config.Config, region string, size string, userData st
 		return droplet, err
 	}
 
-	dropletName := fmt.Sprintf("cloudexec-%v", config.Username)
+	keyName := fmt.Sprintf("cloudexec-%v", config.Username)
+	sshKeyFingerprint, savedPublicKey, err := findSSHKeyOnDigitalOcean(keyName)
 
-	sshKeyFingerprint, savedPublicKey, err := findSSHKeyOnDigitalOcean(dropletName)
+	dropletName := fmt.Sprintf("%s-%v", keyName, jobID)
+
 	if err == nil {
 		if publicKey != savedPublicKey {
 			return droplet, fmt.Errorf("Keys do not match! Consider removing your old key from DigitalOcean Security settings and re-running 'cloudexec launch'.")

--- a/pkg/s3/s3.go
+++ b/pkg/s3/s3.go
@@ -28,20 +28,18 @@ import (
  * - DeleteObject(config config.Config, key string) error
  */
 
-var s3Client *s3.S3
+var s3Client *s3.S3 // cache
 
-// Note: not safe to use concurrently from multiple goroutines (yet)
+// Note: not safe to use concurrently from multiple goroutines (yet?)
 func initializeS3Client(config config.Config, init bool) (*s3.S3, error) {
 	// Immediately return our cached client if available
 	if !init && s3Client != nil {
 		return s3Client, nil
 	}
-
 	// Unpack required config values
 	spacesAccessKey := config.DigitalOcean.SpacesAccessKey
 	spacesSecretKey := config.DigitalOcean.SpacesSecretKey
 	endpoint := fmt.Sprintf("https://%s.digitaloceanspaces.com", config.DigitalOcean.SpacesRegion)
-
 	// Region must be "us-east-1" when creating new Spaces. Otherwise, use the region in your endpoint, such as "nyc3".
 	var spacesRegion string
 	if init {
@@ -49,7 +47,6 @@ func initializeS3Client(config config.Config, init bool) (*s3.S3, error) {
 	} else {
 		spacesRegion = config.DigitalOcean.SpacesRegion
 	}
-
 	// Configure the Spaces client
 	spacesConfig := &aws.Config{
 		Credentials:      credentials.NewStaticCredentials(spacesAccessKey, spacesSecretKey, ""),
@@ -57,17 +54,14 @@ func initializeS3Client(config config.Config, init bool) (*s3.S3, error) {
 		Region:           aws.String(spacesRegion),
 		S3ForcePathStyle: aws.Bool(false),
 	}
-
 	// Create a new session and S3 client
 	newSession, err := session.NewSession(spacesConfig)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to create S3 client: %w", err)
 	}
-
 	if init {
 		return s3.New(newSession), nil
 	}
-
 	// Cache client for subsequent usage iff not the client used for initialization
 	s3Client = s3.New(newSession)
 	return s3Client, nil
@@ -75,24 +69,20 @@ func initializeS3Client(config config.Config, init bool) (*s3.S3, error) {
 
 func ListBuckets(config config.Config) ([]string, error) {
 	var buckets []string = nil
-
 	// create a client
 	s3Client, err := initializeS3Client(config, false)
 	if err != nil {
 		return buckets, err
 	}
-
 	// get bucket details from s3 provider
 	listBucketsOutput, err := s3Client.ListBuckets(&s3.ListBucketsInput{})
 	if err != nil {
 		return buckets, fmt.Errorf("Failed to list buckets: %w", err)
 	}
-
 	// extract just the names from bucket details
 	for _, bucket := range listBucketsOutput.Buckets {
 		buckets = append(buckets, *bucket.Name)
 	}
-
 	return buckets, nil
 }
 
@@ -123,7 +113,6 @@ func CreateBucket(config config.Config) error {
 	if err != nil {
 		return err
 	}
-
 	// execution bucket creation
 	_, err = s3Client.CreateBucket(&s3.CreateBucketInput{
 		Bucket: aws.String(bucketName),
@@ -131,7 +120,6 @@ func CreateBucket(config config.Config) error {
 	if err != nil {
 		return fmt.Errorf("Failed to create bucket '%s': %w", bucketName, err)
 	}
-
 	// wait for the bucket to be available
 	err = s3Client.WaitUntilBucketExists(&s3.HeadBucketInput{
 		Bucket: aws.String(bucketName),
@@ -139,20 +127,18 @@ func CreateBucket(config config.Config) error {
 	if err != nil {
 		return fmt.Errorf("Failed to wait for bucket '%s': %w", bucketName, err)
 	}
-
 	fmt.Printf("Created bucket '%s'...\n", bucketName)
 	return nil
 }
 
-// Note: will overwrite existing object.
+// Note: will overwrite existing objects if they already exist
 func PutObject(config config.Config, key string, value []byte) error {
-	bucketName := fmt.Sprintf("cloudexec-%s", config.Username)
 	// create a client
 	s3Client, err := initializeS3Client(config, false)
 	if err != nil {
 		return err
 	}
-
+	bucketName := fmt.Sprintf("cloudexec-%s", config.Username)
 	// If zero-length value is given, create a directory instead of a file
 	if len(value) == 0 {
 		_, err = s3Client.PutObject(&s3.PutObjectInput{
@@ -165,12 +151,10 @@ func PutObject(config config.Config, key string, value []byte) error {
 		fmt.Printf("Successfully created directory in s3 bucket: %s/%s\n", bucketName, key)
 		return nil
 	}
-
 	// hash the input to ensure the integrity of file
 	// Does the s3 sdk do this for us automatically?
 	md5Hash := md5.Sum(value)
 	md5HashBase64 := base64.StdEncoding.EncodeToString(md5Hash[:])
-
 	// Upload the file
 	_, err = s3Client.PutObject(&s3.PutObjectInput{
 		Bucket:      aws.String(bucketName),
@@ -183,30 +167,16 @@ func PutObject(config config.Config, key string, value []byte) error {
 	if err != nil {
 		return fmt.Errorf("Failed to upload file %s to bucket %s: %w", key, bucketName, err)
 	}
-
 	fmt.Printf("Successfully uploaded file to s3 bucket: %s/%s\n", bucketName, key)
 	return nil
 }
 
-func ObjectExists(config config.Config, key string) (bool, error) {
-	// Get a list of objects that are prefixed by the target key
-	objects, err := ListObjects(config, key)
-	if err != nil {
-		return false, err
-	}
-
-	// return true if we got a non-zero number of objects that match the prefix
-	return len(objects) != 0, nil
-}
-
 func GetObject(config config.Config, key string) ([]byte, error) {
-	bucketName := fmt.Sprintf("cloudexec-%s", config.Username)
-	// create a client
 	s3Client, err := initializeS3Client(config, false)
 	if err != nil {
 		return []byte{}, err
 	}
-
+	bucketName := fmt.Sprintf("cloudexec-%s", config.Username)
 	const maxRetries = 3
 	for i := 1; i <= maxRetries; i++ {
 		resp, err := s3Client.GetObject(&s3.GetObjectInput{
@@ -226,17 +196,14 @@ func GetObject(config config.Config, key string) ([]byte, error) {
 			return nil, fmt.Errorf("Failed to get object: %w", err)
 		}
 		defer resp.Body.Close()
-
 		// Read the object data
 		object, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return nil, fmt.Errorf("Failed to read object data: %w", err)
 		}
-
 		// Calculate the MD5 hash of the downloaded data
 		md5Hash := md5.Sum(object)
 		md5HashHex := fmt.Sprintf(`"%x"`, md5Hash) // ETag is enclosed in double quotes
-
 		// Compare the calculated MD5 hash with the ETag value
 		// Note: may break for large files that are split up amongst several objects
 		if resp.ETag == nil || *resp.ETag != md5HashHex {
@@ -247,11 +214,52 @@ func GetObject(config config.Config, key string) ([]byte, error) {
 				return nil, fmt.Errorf("Data integrity check failed after %d retries: calculated MD5 %s does not match ETag %s", maxRetries, md5HashHex, *resp.ETag)
 			}
 		}
-
 		return object, nil
 	}
-
 	return nil, fmt.Errorf("Failed to get from Spaces bucket: maximum number of retries exceeded")
+}
+
+func ListObjects(config config.Config, prefix string) ([]string, error) {
+	var objects []string
+	// create a client
+	s3Client, err := initializeS3Client(config, false)
+	if err != nil {
+		return objects, err
+	}
+	bucketName := fmt.Sprintf("cloudexec-%s", config.Username)
+	listObjectsInput := &s3.ListObjectsInput{
+		Bucket:  aws.String(bucketName),
+		MaxKeys: aws.Int64(1000),
+	}
+	if len(prefix) != 0 {
+		listObjectsInput.Prefix = aws.String(prefix)
+	}
+	for { // loop through all pages of the object list
+		listObjectsOutput, err := s3Client.ListObjects(listObjectsInput)
+		if err != nil {
+			return objects, fmt.Errorf("Failed to list objects in bucket '%s': %w", bucketName, err)
+		}
+		// extract only the keys from each object
+		for _, object := range listObjectsOutput.Contents {
+			objects = append(objects, *object.Key)
+		}
+		// If no more pages, break out of the loop
+		if !*listObjectsOutput.IsTruncated {
+			break
+		}
+		listObjectsInput.Marker = listObjectsOutput.NextMarker
+	}
+	return objects, nil
+}
+
+func ObjectExists(config config.Config, key string) (bool, error) {
+	// Get a list of objects that are prefixed by the target key
+	objects, err := ListObjects(config, key)
+	if err != nil {
+		return false, err
+	}
+	// return true if we got a non-zero number of objects that match the prefix
+	return len(objects) != 0, nil
 }
 
 func DeleteObject(config config.Config, key string) error {
@@ -261,55 +269,13 @@ func DeleteObject(config config.Config, key string) error {
 	if err != nil {
 		return err
 	}
-
 	deleteObjectInput := &s3.DeleteObjectInput{
 		Bucket: aws.String(bucketName),
 		Key:    aws.String(key),
 	}
-
 	_, err = s3Client.DeleteObject(deleteObjectInput)
 	if err != nil {
 		return fmt.Errorf("Failed to delete object '%s' in bucket '%s': %w", key, bucketName, err)
 	}
-
 	return nil
-}
-
-func ListObjects(config config.Config, prefix string) ([]string, error) {
-	bucketName := fmt.Sprintf("cloudexec-%s", config.Username)
-	var objects []string
-
-	// create a client
-	s3Client, err := initializeS3Client(config, false)
-	if err != nil {
-		return objects, err
-	}
-
-	var listObjectsInput *s3.ListObjectsInput
-	if len(prefix) == 0 {
-		// List all objects in the bucket
-		listObjectsInput = &s3.ListObjectsInput{
-			Bucket:  aws.String(bucketName),
-			MaxKeys: aws.Int64(1000),
-		}
-	} else {
-		// List all objects with keys that begin with the given prefix
-		listObjectsInput = &s3.ListObjectsInput{
-			Bucket:  aws.String(bucketName),
-			Prefix:  aws.String(prefix),
-			MaxKeys: aws.Int64(1000),
-		}
-	}
-
-	listObjectsOutput, err := s3Client.ListObjects(listObjectsInput)
-	if err != nil {
-		return objects, fmt.Errorf("Failed to list objects in bucket '%s': %w", bucketName, err)
-	}
-
-	// extract just the keys from each object
-	for _, object := range listObjectsOutput.Contents {
-		objects = append(objects, *object.Key)
-	}
-
-	return objects, nil
 }

--- a/pkg/ssh/ssh.go
+++ b/pkg/ssh/ssh.go
@@ -278,7 +278,7 @@ func WaitForSSHConnection(jobID int64) error {
 			return fmt.Errorf("Timed out waiting for SSH connection: %w", err)
 		}
 
-		fmt.Printf("Can't connect to %s@%s:%s yet, retrying in %v...\n", user, ipAddress, port, retryInterval)
+		fmt.Printf("Can't connect to %s yet, retrying in %v...\n", hostname, retryInterval)
 		time.Sleep(retryInterval)
 	}
 }

--- a/pkg/ssh/ssh.go
+++ b/pkg/ssh/ssh.go
@@ -151,7 +151,7 @@ func GetOrCreateSSHKeyPair() (string, error) {
 	return string(publicKeySSHFormat), nil
 }
 
-func AddSSHConfig(jobId int64, ipAddress string) error {
+func AddSSHConfig(jobID int64, ipAddress string) error {
 	err := EnsureSSHIncludeConfig()
 	if err != nil {
 		return fmt.Errorf("Failed to validate main SSH config: %w", err)
@@ -161,7 +161,7 @@ func AddSSHConfig(jobId int64, ipAddress string) error {
 		return err
 	}
 	configDir := filepath.Join(sshDir, "config.d")
-	hostname := fmt.Sprintf("cloudexec-%v", jobId)
+	hostname := fmt.Sprintf("cloudexec-%v", jobID)
 	configPath := filepath.Join(configDir, hostname)
 	identityFile := filepath.Join(sshDir, "cloudexec-key")
 	// Create the SSH config directory if it does not exist
@@ -177,7 +177,7 @@ func AddSSHConfig(jobId int64, ipAddress string) error {
 	defer configFile.Close()
 	// Write the templated host config to file
 	config := HostConfig{
-		JobID:        jobId,
+		JobID:        jobID,
 		IPAddress:    ipAddress,
 		IdentityFile: identityFile,
 	}
@@ -193,7 +193,7 @@ func AddSSHConfig(jobId int64, ipAddress string) error {
 	return nil
 }
 
-func DeleteSSHConfig(jobId int64) error {
+func DeleteSSHConfig(jobID int64) error {
 	err := EnsureSSHIncludeConfig()
 	if err != nil {
 		return fmt.Errorf("Failed to validate SSH config: %w", err)
@@ -203,7 +203,7 @@ func DeleteSSHConfig(jobId int64) error {
 		return err
 	}
 	configDir := filepath.Join(sshDir, "config.d")
-	hostname := fmt.Sprintf("cloudexec-%v", jobId)
+	hostname := fmt.Sprintf("cloudexec-%v", jobID)
 	configPath := filepath.Join(configDir, hostname)
 	err = os.Remove(configPath)
 	if err != nil && !os.IsNotExist(err) {
@@ -216,12 +216,12 @@ func DeleteSSHConfig(jobId int64) error {
 	return nil
 }
 
-func WaitForSSHConnection(jobId int64) error {
+func WaitForSSHConnection(jobID int64) error {
 	sshDir, err := getSSHDir()
 	if err != nil {
 		return err
 	}
-	hostname := fmt.Sprintf("cloudexec-%v", jobId)
+	hostname := fmt.Sprintf("cloudexec-%v", jobID)
 	hostname = strings.ReplaceAll(hostname, ".", "-")
 	sshConfigPath := filepath.Join(sshDir, "config.d", hostname)
 
@@ -283,8 +283,8 @@ func WaitForSSHConnection(jobId int64) error {
 	}
 }
 
-func StreamLogs(jobId int64) error {
-	hostname := fmt.Sprintf("cloudexec-%v", jobId)
+func StreamLogs(jobID int64) error {
+	hostname := fmt.Sprintf("cloudexec-%v", jobID)
 	// Stream the logs from the server with tail -f
 	sshCmd := exec.Command("ssh", hostname, "tail", "-f", "/var/log/cloud-init-output.log")
 	sshCmd.Stdout = os.Stdout
@@ -296,8 +296,8 @@ func StreamLogs(jobId int64) error {
 	return nil
 }
 
-func AttachToTmuxSession(jobId int64) error {
-	hostname := fmt.Sprintf("cloudexec-%v", jobId)
+func AttachToTmuxSession(jobID int64) error {
+	hostname := fmt.Sprintf("cloudexec-%v", jobID)
 	sshCmd := exec.Command("ssh", "-t", hostname, "tmux", "attach-session", "-t", "cloudexec")
 
 	// Connect the SSH command to the current terminal

--- a/pkg/ssh/ssh.go
+++ b/pkg/ssh/ssh.go
@@ -211,7 +211,7 @@ func DeleteSSHConfig(jobID int64) error {
 	}
 	// If there's no error, the file was deleted successfully
 	if err == nil {
-		fmt.Println("Deleted old SSH config file")
+		fmt.Printf("Deleted SSH config for job-%v\n", jobID)
 	}
 	return nil
 }


### PR DESCRIPTION
- Add pagination support to object getter, overcoming the prior limit of 1000 objects at a time
- separate a CleanJob function out from CleanAll
- add job flag to the clean command
- use flag for specifying output path to pull into instead of an argument, give this param a sensible default
- add force flag to clean/reset commands to bypass user confirmation
- add pull-and-clean metacommand
<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- New Feature: Introduced `MergeAndSave` function in `state` package for efficient state management.
- New Feature: Enhanced `DownloadJobOutput` function in `pull.go` to handle log downloads and local directory creation.
- Bug Fix: Modified `PrintStatus` function in `status.go` to display the latest job instead of the latest completed job, providing real-time status updates.
- Refactor: Updated S3 upload path in `user_data.sh.tmpl` for cloud-init logs, improving log organization.
- Refactor: Standardized naming convention for `jobID` across `digitalocean.go` and `ssh.go`, enhancing code consistency.
- Chore: Introduced a new variable `keyName` in `digitalocean.go` for better droplet name formatting.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->